### PR TITLE
Drops Fedora28 and CentOS6.x from our support OS

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -22,13 +22,16 @@ This page provides information about local development of each subsystem and con
 K2HR3 currently depends on the following software.
 
 * Linux
-  * Debian-9, Fedora-28(29), CentOS-7, Ubuntu-18.04
+  * Debian buster and Stretch
+  * Fedora 32, 31 and 30
+  * CentOS 7 and 8
+  * Ubuntu 16.04, 18.04, and 20.04
 * OpenStack
-  * We have tested K2HR3 with OpenStack Rocky.
+  * Ussuri
 * Node.js
-  * Node.js 4.x or higher
+  * Node.js 10.x, 12.x and 14.x
 * Python
-  * Python 3.5 or higher
+  * Python 3.6 and 3.8
   
 
 ## K2HR3 Repositories structure
@@ -67,7 +70,7 @@ k2hr3_api repository is a repository for K2HR3 API server.
 
 3. install dependent packages to your local development environment. To build a k2hr3_api package, *k2hdkc* shared library and the header files are required.
    
-    For Debian(Stretch) or Ubuntu(Bionic Beaver) users, run the following commands::
+    For recent Debian-based Linux distributions users, follow the steps below::
     ```
     $ sudo apt-get update -y
     $ sudo apt-get install curl -y
@@ -82,7 +85,15 @@ k2hr3_api repository is a repository for K2HR3 API server.
     $ scl enable devtoolset-7 bash
     ```
 
-    For Fedora28 or CentOS7 users, run the following commands::
+    For users who use supported Fedora other than latest version, follow the steps below::
+    ```
+    $ sudo dnf makecache
+    $ sudo dnf install curl -y
+    $ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+    $ sudo dnf install k2hdkc-devel
+    ```
+
+    For other recent RPM-based Linux distributions users, follow the steps below::
     ```
     $ sudo yum makecache
     $ sudo yum install curl -y

--- a/developerja.md
+++ b/developerja.md
@@ -55,7 +55,7 @@ k2hr3_apiレポジトリは、APIサーバー用レポジトリです。
 3. ローカル環境に必要なパッケージをインストールします。
     パッケージのビルドには、**k2hdkc** のライブラリとヘッダファイルが必要となります。
    
-    Debian(Stretch) / Ubuntu(Bionic Beaver)をお使いの場合は次のように実行してください。
+    最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
     ```
     $ sudo apt-get update -y
     $ sudo apt-get install curl -y
@@ -70,7 +70,15 @@ k2hr3_apiレポジトリは、APIサーバー用レポジトリです。
     $ scl enable devtoolset-7 bash
     ```
 
-    Fedora28 / CentOS7.xをお使いの場合は次のように実行してください。
+    Fedoraの利用者は、以下の手順に従ってください。
+    ```
+    $ sudo dnf makecache
+    $ sudo dnf install curl -y
+    $ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+    $ sudo dnf install k2hdkc-devel
+    ```
+
+    その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
     ```
     $ sudo yum makecache
     $ sudo yum install curl -y

--- a/introduce.md
+++ b/introduce.md
@@ -103,10 +103,17 @@ As a RBAC system, K2HR3 in cloud environments has unique features that enable de
 ## Future of K2HR3
 
 The current version of K2HR3 is 0.9.0. It is still in the beta stage. Give us feedback or submit a pull request through the [GitHub website](https://github.com/yahoojapan/k2hr3) for a stable version. We have currently tested K2HR3-0.9.0 on the following environments:
-- OS  
-Debian 9, Fedora 28(29), CentOS 7, Ubuntu 18.04
-- IaaS  
-OpenStack Rocky
+* Linux
+  * Debian buster and Stretch
+  * Fedora 32, 31 and 30
+  * CentOS 7 and 8
+  * Ubuntu 16.04, 18.04, and 20.04
+* OpenStack
+  * Ussuri
+* Node.js
+  * Node.js 10.x, 12.x and 14.x
+* Python
+  * Python 3.6 and 3.8
 
 We also want your request for comments on the future K2HR3. We will improve the current **+SERVICE** and the other features. For example, we have a plan to support [Kubernetes](https://kubernetes.io/) to manage containers as a member of a role. We also plan to provide developers and service administrators with a simple way to start K2HR3 cluster. 
 

--- a/setup.md
+++ b/setup.md
@@ -24,14 +24,16 @@ If you want to easily build and try a minimal K2HR3 system, see [Build a Trial E
 K2HR3 currently depends on the following software.
 
 * Linux
-  * Debian-9, Fedora-28(29), CentOS-7, Ubuntu-18.04
+  * Debian buster and Stretch
+  * Fedora 32, 31 and 30
+  * CentOS 7 and 8
+  * Ubuntu 16.04, 18.04, and 20.04
 * OpenStack
-  * We have tested K2HR3 with OpenStack Rocky.
+  * Ussuri
 * Node.js
-  * Node.js 4.x or higher
+  * Node.js 10.x, 12.x and 14.x
 * Python
-  * Python 3.5 or higher
-  
+  * Python 3.6 and 3.8 
 
 ## K2HR3 System Overview
 


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
This PR removes unsupported OS descrptions from the manuals.