### PR TITLE
Added k2hdkc_helm_chart repository to gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "k2hr3_cli"]
 	path = k2hr3_cli
 	url = https://github.com/yahoojapan/k2hr3_cli.git
+[submodule "k2hdkc_helm_chart"]
+	path = k2hdkc_helm_chart
+	url = https://github.com/yahoojapan/k2hdkc_helm_chart.git


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
It has been added to the submodule for the https://github.com/yahoojapan/k2hr3_helm_chart repository.
